### PR TITLE
Add Federated Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ Want to learn more?
   - https://github.com/rjsteinert/outbox
 - Remark template, fork it to create your own presentations using [remarkjs](https://remarkjs.com)
   - dat://remark-rangermauve.hashbase.io/
+- Federated Wiki
+  - dat://federated-wiki-client.hashbase.io/
+  - https://github.com/paul90/wiki-client-dat-variant
 
 ## Games
 


### PR DESCRIPTION
Adding my recent variant of the Federated Wiki client that uses dat rather than a server for page storage.

While it has access to the wider http(s) known wiki federation for wiki created with this client needed to be mirrored to https, using Hasebase/Homebase, for them to be accessible from the http(s) parts of the federation.