### PR TITLE
renames Cryptic's file editor to Dat File Editor

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
         <div class="entries space2x">
           <a class="entry bigfixheight stretch" href="dat://editor-cryptic.hashbase.io/" target="_blank">
             <div class="entry-content" data-label="app">
-              <img class="entry-img" src="/images/cryptics-file-editor.png">
+              <img class="entry-img" src="/images/editor-cryptic.png">
               <div class="entry-desc">
                 <h3 class="entry-title">Dat File editor</h3>
                 <p class="entry-description">In-browser editor for dat:// files</p>
@@ -360,7 +360,7 @@
           </div>
           <a class="entry bigfixheight stretch" href="dat://editor-cryptic.hashbase.io/" target="_blank">
             <div class="entry-content" data-label="app">
-              <img class="entry-img" src="/images/cryptics-file-editor.png">
+              <img class="entry-img" src="/images/editor-cryptic.png">
               <div class="entry-desc">
                 <h3 class="entry-title">Dat File editor</h3>
                 <p class="entry-description">In-browser editor for dat:// files</p>

--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@
             <div class="entry-content" data-label="app">
               <img class="entry-img" src="/images/cryptics-file-editor.png">
               <div class="entry-desc">
-                <h3 class="entry-title">Cryptic's File editor</h3>
+                <h3 class="entry-title">Dat File editor</h3>
                 <p class="entry-description">In-browser editor for dat:// files</p>
               </div>
             </div>
@@ -362,7 +362,7 @@
             <div class="entry-content" data-label="app">
               <img class="entry-img" src="/images/cryptics-file-editor.png">
               <div class="entry-desc">
-                <h3 class="entry-title">Cryptic's File editor</h3>
+                <h3 class="entry-title">Dat File editor</h3>
                 <p class="entry-description">In-browser editor for dat:// files</p>
               </div>
             </div>


### PR DESCRIPTION
Not sure why it was named Cryptic's file editor here, the actual name is Dat File Editor (https://github.com/cryptowyrm/datfileeditor) so this pull request fixes the name.

Since the picture used for it said "Cryptic's file editor" as well, I noticed there was a screenshot already in the images directory so I just changed the code to use that image instead.

If the name Dat File Editor shouldn't be used here for any reason, you can leave it as is, I'm totally fine with that :)