### PR TITLE
Add link to live website in README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Explore the peer-to-peer Web
+# [Explore the peer-to-peer Web](https://explore.beakerbrowser.com/)
 
 A curated list of peer-to-peer websites and apps.
 


### PR DESCRIPTION
I noticed the footer link for "Explore what others have built" on https://beakerbrowser.com/docs/ (which I clicked) takes you here, which is great but also not great if you wanted to view the website!

We should also/instead add the link to https://explore.beakerbrowser.com/ on this repo's Settings page for better good times.

p.s. came here looking for fritter since Beaker Browser has grown up considerably since i last had a chance to hack on it! very exciting times and good work everyone.